### PR TITLE
35. Add loading screen

### DIFF
--- a/Project Walking/Source code/app/src/main/java/com/teamapricot/projectwalking/view/MainActivity.java
+++ b/Project Walking/Source code/app/src/main/java/com/teamapricot/projectwalking/view/MainActivity.java
@@ -172,19 +172,14 @@ public class MainActivity extends AppCompatActivity {
         navigationController.registerOnClickListener(removeDestinationButton);
     }
 
+    /**
+     * Shows a loading screen if the map has not been initialized
+     * @param tilesOverlay The {@link TilesOverlay} to use to check whether or not the map has been initialized
+     */
     private void showLoadingScreen(TilesOverlay tilesOverlay) {
         CompletableFuture.runAsync(() -> {
             if (!tilesOverlay.getTileStates().isDone()) {
-                Log.d("MainActivity", "Map is loading...");
                 runOnUiThread(() -> mapLoadingDialog.show(getSupportFragmentManager(), "MapLoading"));
-
-                while (!tilesOverlay.getTileStates().isDone()) {
-                    try {
-                        Thread.sleep(500);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                }
             }
         }, Executors.newSingleThreadExecutor());
     }

--- a/Project Walking/Source code/app/src/main/java/com/teamapricot/projectwalking/view/MainActivity.java
+++ b/Project Walking/Source code/app/src/main/java/com/teamapricot/projectwalking/view/MainActivity.java
@@ -22,6 +22,7 @@ import com.teamapricot.projectwalking.model.CameraModel;
 import com.teamapricot.projectwalking.model.NavigationModel;
 import com.teamapricot.projectwalking.model.database.Database;
 import com.teamapricot.projectwalking.observe.Observer;
+import com.teamapricot.projectwalking.view.dialogs.MapLoadingDialog;
 
 import org.osmdroid.api.IMapController;
 import org.osmdroid.config.Configuration;
@@ -30,14 +31,17 @@ import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.Marker;
 import org.osmdroid.views.overlay.Polyline;
+import org.osmdroid.views.overlay.TilesOverlay;
 import org.osmdroid.views.overlay.mylocation.GpsMyLocationProvider;
 import org.osmdroid.views.overlay.mylocation.MyLocationNewOverlay;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 
 public class MainActivity extends AppCompatActivity {
     private static final double ALLOWED_DISTANCE = 20;
-    
+
     private NavigationController navigationController;
     private CameraController cameraController;
     private ImageOverlayController imageOverlayController;
@@ -60,6 +64,8 @@ public class MainActivity extends AppCompatActivity {
 
     private MapView map = null;
 
+    private final MapLoadingDialog mapLoadingDialog = new MapLoadingDialog(this);
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -80,14 +86,18 @@ public class MainActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
 
-        map.onResume();
+        if (map != null) {
+            map.onResume();
+        }
     }
 
     @Override
     protected void onPause() {
         super.onPause();
 
-        map.onPause();
+        if (map != null) {
+            map.onPause();
+        }
     }
 
     @Override
@@ -144,6 +154,7 @@ public class MainActivity extends AppCompatActivity {
         map = findViewById(R.id.map);
         map.setTileSource(TileSourceFactory.MAPNIK);
         map.setMultiTouchControls(true);
+        showLoadingScreen(map.getOverlayManager().getTilesOverlay());
 
         mapController = map.getController();
 
@@ -159,6 +170,23 @@ public class MainActivity extends AppCompatActivity {
         navigationController.start();
         navigationController.registerOnClickListener(addDestinationButton);
         navigationController.registerOnClickListener(removeDestinationButton);
+    }
+
+    private void showLoadingScreen(TilesOverlay tilesOverlay) {
+        CompletableFuture.runAsync(() -> {
+            if (!tilesOverlay.getTileStates().isDone()) {
+                Log.d("MainActivity", "Map is loading...");
+                runOnUiThread(() -> mapLoadingDialog.show(getSupportFragmentManager(), "MapLoading"));
+
+                while (!tilesOverlay.getTileStates().isDone()) {
+                    try {
+                        Thread.sleep(500);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }, Executors.newSingleThreadExecutor());
     }
 
     private void initImageOverlay() {
@@ -219,6 +247,7 @@ public class MainActivity extends AppCompatActivity {
 
     /**
      * Creates a new {@code Observer} object for the Camera functionality
+     * 
      * @return
      */
     private Observer<CameraModel> createCameraObserver() {
@@ -247,7 +276,9 @@ public class MainActivity extends AppCompatActivity {
 
     /**
      * Creates a new {@code Observer} object for the navigation functionality
-     * @return An {@code Observer<NavigationModel>} object to observe changes in a {@code NavigationModel} and update the UI correspondingly
+     * 
+     * @return An {@code Observer<NavigationModel>} object to observe changes in a
+     *         {@code NavigationModel} and update the UI correspondingly
      */
     private Observer<NavigationModel> createNavigationObserver() {
         return model -> {
@@ -262,12 +293,13 @@ public class MainActivity extends AppCompatActivity {
                         mapController.setCenter(location);
                         mapCentered = true;
                         oldDestination = destination;
+                        mapLoadingDialog.dismiss();
                         return;
                     }
                 }
 
-                if(destination != null && destination != oldDestination) {
-                    //center on user movement
+                if (destination != null && destination != oldDestination) {
+                    // center on user movement
                     if (!model.getFollowLocation() && model.getBoundingBox() != null) {
                         locationOverlay.disableFollowLocation();
                         map.zoomToBoundingBox(model.getBoundingBox(), true, 150);
@@ -278,8 +310,7 @@ public class MainActivity extends AppCompatActivity {
                 if (model.getFollowLocation() != previousFollowLocation) {
                     if (model.getFollowLocation()) {
                         locationOverlay.enableFollowLocation();
-                    }
-                    else {
+                    } else {
                         locationOverlay.disableFollowLocation();
                     }
                     map.invalidate();
@@ -291,7 +322,7 @@ public class MainActivity extends AppCompatActivity {
                     return;
                 }
 
-                if(destinationMarker != null && destination == null) {
+                if (destinationMarker != null && destination == null) {
                     map.getOverlays().remove(destinationMarker);
                     map.invalidate();
                     destinationMarker = null;
@@ -299,7 +330,7 @@ public class MainActivity extends AppCompatActivity {
                     destinationMarker = addMarker(map, destination);
                 }
 
-                if(routeOverlay != null) {
+                if (routeOverlay != null) {
                     map.getOverlays().remove(routeOverlay);
                     map.invalidate();
                 }

--- a/Project Walking/Source code/app/src/main/java/com/teamapricot/projectwalking/view/dialogs/MapLoadingDialog.java
+++ b/Project Walking/Source code/app/src/main/java/com/teamapricot/projectwalking/view/dialogs/MapLoadingDialog.java
@@ -25,14 +25,6 @@ public class MapLoadingDialog extends DialogFragment {
         this.activity = activity;
     }
 
-    public void updateProgress(int progress) {
-        this.progress = progress;
-
-        if (progressBar != null) {
-            progressBar.setProgress(progress);
-        }
-    }
-
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstance) {

--- a/Project Walking/Source code/app/src/main/java/com/teamapricot/projectwalking/view/dialogs/MapLoadingDialog.java
+++ b/Project Walking/Source code/app/src/main/java/com/teamapricot/projectwalking/view/dialogs/MapLoadingDialog.java
@@ -1,0 +1,50 @@
+package com.teamapricot.projectwalking.view.dialogs;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.ProgressBar;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.DialogFragment;
+
+import com.teamapricot.projectwalking.R;
+
+public class MapLoadingDialog extends DialogFragment {
+    private final AppCompatActivity activity;
+    private final String TITLE = "Loading map";
+
+    private ProgressBar progressBar;
+    private int progress = 0;
+
+    public MapLoadingDialog(AppCompatActivity activity) {
+        this.activity = activity;
+    }
+
+    public void updateProgress(int progress) {
+        this.progress = progress;
+
+        if (progressBar != null) {
+            progressBar.setProgress(progress);
+        }
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstance) {
+        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(getActivity());
+        dialogBuilder.setTitle(TITLE)
+                .setView(R.layout.dialog_map_loading);
+
+        return dialogBuilder.create();
+    }
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        this.progressBar = view.findViewById(R.id.map_loading_progress_bar);
+    }
+}

--- a/Project Walking/Source code/app/src/main/java/com/teamapricot/projectwalking/view/dialogs/MapLoadingDialog.java
+++ b/Project Walking/Source code/app/src/main/java/com/teamapricot/projectwalking/view/dialogs/MapLoadingDialog.java
@@ -3,6 +3,7 @@ package com.teamapricot.projectwalking.view.dialogs;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.os.Bundle;
+import android.view.KeyEvent;
 import android.view.View;
 import android.widget.ProgressBar;
 
@@ -39,6 +40,15 @@ public class MapLoadingDialog extends DialogFragment {
         dialogBuilder.setTitle(TITLE)
                 .setCancelable(false)
                 .setView(R.layout.dialog_map_loading);
+
+        dialogBuilder.setOnKeyListener((dialog, keyCode, event) -> {
+            if(keyCode == KeyEvent.KEYCODE_BACK && event.getAction() == KeyEvent.ACTION_UP) {
+                return true; // Consumed
+            }
+            else {
+                return false; // Not consumed
+            }
+        });
 
         Dialog dialog = dialogBuilder.create();
         dialog.setCanceledOnTouchOutside(false);

--- a/Project Walking/Source code/app/src/main/java/com/teamapricot/projectwalking/view/dialogs/MapLoadingDialog.java
+++ b/Project Walking/Source code/app/src/main/java/com/teamapricot/projectwalking/view/dialogs/MapLoadingDialog.java
@@ -37,9 +37,13 @@ public class MapLoadingDialog extends DialogFragment {
     public Dialog onCreateDialog(Bundle savedInstance) {
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(getActivity());
         dialogBuilder.setTitle(TITLE)
+                .setCancelable(false)
                 .setView(R.layout.dialog_map_loading);
 
-        return dialogBuilder.create();
+        Dialog dialog = dialogBuilder.create();
+        dialog.setCanceledOnTouchOutside(false);
+
+        return dialog;
     }
 
     @Override

--- a/Project Walking/Source code/app/src/main/res/layout/dialog_map_loading.xml
+++ b/Project Walking/Source code/app/src/main/res/layout/dialog_map_loading.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <ProgressBar
+        android:id="@+id/map_loading_progress_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/text_margin"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:progress="0" />
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Closes #97 

These changes add a loading screen on startup that will disappear when the app is ready to be used.

The loading screen stays on the screen until the first location update has been added, which will result in the user being centered on the map, and the relevant UI items being visible when the loading screen disappears.

The user cannot close this loading screen, it will stay on the screen until the app has loaded completely.

<img src="https://user-images.githubusercontent.com/4168364/137591496-80c7df96-b86f-42a0-88df-ab9a88ee1ab3.png" width=250 />